### PR TITLE
Attestation Verification for Delegated Proving

### DIFF
--- a/crates/miden-proving-service-client/Cargo.toml
+++ b/crates/miden-proving-service-client/Cargo.toml
@@ -26,13 +26,14 @@ tonic = { version = "0.12", default-features = false, features = ["prost", "code
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
-tonic = { version = "0.12", default-features = false, features = ["prost", "codegen", "transport"] }
+tonic = { version = "0.12", default-features = false, features = ["prost", "codegen", "transport", "tls","tls-roots"] }
 tonic-web = { version = "0.12", optional = true }
 
 [dependencies]
 async-trait = "0.1"
 miden-objects = { workspace = true, default-features = false, optional = true }
 miden-tx = { workspace = true, default-features = false, optional = true }
+lunal-attestation = { git = "https://github.com/lunal-dot-dev/attestation-rs.git" }
 prost = { version = "0.13", default-features = false, features = ["derive"] }
 thiserror = "2.0"
 tokio = { version = "1.44", default-features = false, features = ["sync"], optional = true }
@@ -43,4 +44,3 @@ prost = { version = "0.13", default-features = false, features = ["derive"] }
 prost-build = { version = "0.13" }
 protox = { version = "0.7" }
 tonic-build = { version = "0.12" }
-

--- a/crates/miden-proving-service-client/src/proving_service/tx_prover.rs
+++ b/crates/miden-proving-service-client/src/proving_service/tx_prover.rs
@@ -4,6 +4,7 @@ use alloc::{
     sync::Arc,
 };
 
+use lunal_attestation::verify::verify_attestation;
 use miden_objects::{
     transaction::{ProvenTransaction, TransactionWitness},
     utils::{Deserializable, DeserializationError, Serializable},
@@ -66,8 +67,19 @@ impl RemoteTransactionProver {
         };
 
         #[cfg(not(target_arch = "wasm32"))]
+        use tonic::transport::Endpoint;
+        let mut endpoint = Endpoint::from_shared(self.endpoint.clone())
+            .map_err(|_| RemoteProverError::ConnectionFailed(self.endpoint.to_string()))?;
+
+        // enable TLS for HTTPs endpoints
+        if self.endpoint.starts_with("https://") {
+            endpoint = endpoint
+                .tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots())
+                .map_err(|e| RemoteProverError::ConnectionFailed(e.to_string()))?;
+        }
+
         let new_client = {
-            ApiClient::connect(self.endpoint.clone())
+            ApiClient::connect(endpoint)
                 .await
                 .map_err(|_| RemoteProverError::ConnectionFailed(self.endpoint.to_string()))?
         };
@@ -102,6 +114,17 @@ impl TransactionProver for RemoteTransactionProver {
         let response = client.prove(request).await.map_err(|err| {
             TransactionProverError::other_with_source("failed to prove transaction", err)
         })?;
+
+        // Extract the attestation report from metadata
+        if let Some(attestation_value) = response.metadata().get("Attestation-Report") {
+            // Verify the attestation
+            verify_attestation(attestation_value.to_str()).await.map_err(|err| {
+                TransactionProverError::other_with_source(
+                    "failed to verify transaction attestation",
+                    err,
+                )
+            })?;
+        }
 
         // Deserialize the response bytes back into a ProvenTransaction.
         let proven_transaction =


### PR DESCRIPTION
## Overview

This PR adds Trusted Execution Environment (TEE) attestation report verification to proving service clients. With this PR, clients can verify that their delegated prover was run inside a TEE and thus preserved the input and processing privacy of their request.

**Note**: We tested this end-to-end on versions 0.8.1 of the miden client and the miden prover proxy. The reason behind using these versions is for compatibility with the Miden Testnet. 

## Implementation Details

### Changes

**Attestation Verification Integration**

- Add TEE attestation report verification to the proving service client.
- Verify attestation reports attached in the `Attestation-Report` HTTP response header from TEE-enabled delegated provers.

**New Dependencies**

- [attestation-rs](https://github.com/lunal-dot-dev/attestation-rs) - Open source rust attestation verification library that verifies TEE attestation reports written by lunal.

### Architecture

1. Client submits a proving request to a delegated prover running inside a TEE.
2. The delegated prover in the TEE processes the client request and generates a proof.
3. The delegated prover returned the generated proof and a cryptographic attestation report in the HTTP response.
4. The client verifies the attestation report and confirms the proof was generated in a private, trusted environment.
5. Now verified, the standard proving workflow continues from there.

### **Backwards Compatibility**

- If an attestation report is present in the `Attestation-Report` HTTP response header? → Verify the attestation.
- If there’s no `Attestation-Report` response header or no attestation report in the `Attestation-Report` response headers? → Proceed without verification (legacy behavior).
- No breaking changes to existing client configurations.

### Testing Changes

To test:

- Spin up a delegated prover inside a TEE (this can be provided by Lunal folks). This will have an endpoint (e.g [`https://miden.lunal.dev/`](https://miden-prover.lunal.dev/))
- Initialize a local miden client (https://github.com/0xMiden/miden-client)
- In the `miden-client.toml` , set the `remote_rpc_endpoint` to the delegated prover url:
    
    ```toml
    remote_prover_endpoint = "https://miden-prover.lunal.dev"
    ```
    

## Migration Strategy

**Phase 1: Parallel Deployment**

- Deploy TEE-secured delegated prover(s) alongside existing, non-TEE-secured delegated provers.
- Separate, independent endpoints will exist in parallel for testing and gradual adoption.
- Full backward compatibility maintained.

**Phase 2: Testing & Validation**

- End-to-end, production testing with TEE delegated provers.
- Validate client-side attestation verification.
- Benchmark performance and reliability.

**Phase 3: Transition (Optional)**

- Gradual migration of all traffic to TEE-secured delegated provers.
- Optional requirement and enforcement of attestations by clients.
- Graceful deprecation of non-TEE, non-private delegated provers.